### PR TITLE
Replace nullish coalescing operator with default function parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,14 +12,13 @@ const theFinder = new RegExp(
 const findDecorators = (fileContent) =>
   theFinder.test(stripComments(fileContent));
 
-const esbuildPluginTsc = (options = {}) => ({
+const esbuildPluginTsc = ({
+  tsconfigPath = path.join(process.cwd(), './tsconfig.json'),
+  force: forceTsc = false,
+  tsx = true,
+} = {}) => ({
   name: 'tsc',
   setup(build) {
-    const tsconfigPath =
-      options.tsconfigPath ?? path.join(process.cwd(), './tsconfig.json');
-    const forceTsc = options.force ?? false;
-    const tsx = options.tsx ?? true;
-
     let parsedTsConfig = null;
 
     build.onLoad({ filter: tsx ? /\.tsx?$/ : /\.ts$/ }, async (args) => {


### PR DESCRIPTION
Nullish coalescing operator has been supported since nodejs 14, so replaced with default function parameters to support in previous nodejs versions. (e.g. nodejs12)

(see https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)