### PR TITLE
Fix file name in sourcemaps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,10 @@ const esbuildPluginTsc = ({
         return;
       }
 
-      const program = typescript.transpileModule(ts, { compilerOptions: parsedTsConfig.options });
+      const program = typescript.transpileModule(ts, {
+        compilerOptions: parsedTsConfig.options,
+        fileName: path.basename(args.path),
+      });
       return { contents: program.outputText };
     });
   },


### PR DESCRIPTION
When creating a bundle with typescript enabled, files that contain decorators don't show up well in the source maps. The filename is always `module.ts`. This PR addresses this issue so that the original filename shows up in the result.

Compare the paths in the stack trace I pulled from an AWS lambda function:

**Before**
```
Error: Couldn't find sso credentials
    at qge.findSsoCredentials (/src/authentication/db/module.ts:70:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at nbe.ssoAcademy (/src/sso/module.ts:37:28)
```

**After**
```
Error: Couldn't find sso credentials
    at qge.findSsoCredentials (/src/authentication/db/Query.ts:70:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at nbe.ssoAcademy (/src/sso/SSOController.ts:37:28)
```