### PR TITLE
Allow to be used alongside typescript version 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "esbuild-plugin-tsc",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2486,9 +2486,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   "devDependencies": {
     "jest": "^28.1.1",
     "prettier": "^2.7.1",
-    "typescript": "^4.7.4"
+    "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   }
 }


### PR DESCRIPTION
[TypeScript version 5 was released](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/) with no [API breaking change](https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes#typescript-50) that affects the library