### PR TITLE
Add ESM Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ esbuildPluginTsc({
     tsconfigPath?: string,
     // If true, force compilation with tsc
     force?: boolean,
+    // If true, force TypeScript to treat files without the `.mts` extension as ESM
+    forceEsm?: boolean,
     // If true, enables tsx file support
     tsx?: boolean
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,6 +3,8 @@ declare function esbuildPluginTsc(options?: {
   tsconfigPath?: string;
   // If true, force compilation with tsc
   force?: boolean;
+  // If true, force TypeScript to treat files without the `.mts` extension as ESM
+  forceEsm?: boolean;
   // If true, enables tsx file support
   tsx?: boolean;
 }): {


### PR DESCRIPTION
When using `format: "esm"`, with esbuild, this plugin will produce runtime errors because TypeScript will transpile the module to CommonJS. You'll even get a warning from esbuild:

```
[WARNING] The CommonJS "exports" variable is treated as a
global variable in an ECMAScript module and may not work as expected
```

The canonical way to get TypeScript to treat input files as ESM is to use the [`.mts` file extension](https://github.com/microsoft/TypeScript/issues/53022#issuecomment-1533644934). However, this plugin will filter those files and they won't be compiled by typescript. To fix this I updated the filter regex to allow `.mts` and `.mtsx`.

In addition, a lot of folks likely do not use the `.mts` extension and renaming the files of a large project would likely be tedious so I added an option to force TypeScript to treat the files as ESM.